### PR TITLE
Added strace to the list of softwares

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pacman -Sy --noconfirm \
 	gcc \
 	zsh \
 	curl \
+	strace \
 	gdb \
 	radare2 \
 	nasm \


### PR DESCRIPTION
Strace is very useful to know which syscall is made when a program is launched. It can help during the reconnaissance phase to know if for example a program does a setuid to 0.